### PR TITLE
Fix unwanted "1" directory generation during localization output

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -684,7 +684,7 @@ Future<List<io.File>> generateArbFiles({
     final (:bucket, :locale, :bytes) = iterator.current;
     final fileName = '${prefix ?? 'app'}_$locale.arb';
     final filePath = path.normalize(
-      path.join(arbDirectory.path, bucket, fileName),
+      path.join(arbDirectory.path, fileName),
     );
     final file = io.File(filePath);
     toDelete.remove(filePath);
@@ -781,7 +781,7 @@ Future<Set<String>> generateFlutterLocalization({
 
   for (final dir in toGenerate) {
     final bucket = path.basename(dir);
-    final genPath = path.normalize(path.join(genDirectory.path, bucket));
+    final genPath = path.normalize(genDirectory.path);
     if (!genPath.startsWith(libDirectory.path)) {
       $err('Gen path is outside of the library directory: $genPath');
       io.exit(1);


### PR DESCRIPTION
I noticed that the generator creates an unexpected directory named "1" during the localization output process.  
After investigating, it appears to be caused by using `path.basename(dir)` to build the output path, which may resolve to numeric or unintended values depending on the input.

I changed the path generation logic to use the provided generation directory directly, without creating an additional bucket folder.

Changes:
- Use `arbDirectory.path` directly when resolving ARB file paths
- Remove bucket-based directory generation for localization output


If there are any suggestions or improvements, I would be happy to review them and make the implementation better.